### PR TITLE
[2/4] Gina-Update-Rack-SDK-for-ruby 3.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,26 +59,7 @@ build-iPhoneSimulator/
 # Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
 
 # User-specific stuff:
-.idea/workspace.xml
-.idea/tasks.xml
-.idea/dictionaries
-.idea/vcs.xml
-.idea/jsLibraryMappings.xml
-
-# Sensitive or high-churn files:
-.idea/dataSources.ids
-.idea/dataSources.xml
-.idea/dataSources.local.xml
-.idea/sqlDataSources.xml
-.idea/dynamic.xml
-.idea/uiDesigner.xml
-
-# Gradle:
-.idea/gradle.xml
-.idea/libraries
-
-# Mongo Explorer plugin:
-.idea/mongoSettings.xml
+.idea/
 
 ## File-based project format:
 *.iws
@@ -88,8 +69,6 @@ build-iPhoneSimulator/
 # IntelliJ
 /out/
 
-# mpeltonen/sbt-idea plugin
-.idea_modules/
 
 # JIRA plugin
 atlassian-ide-plugin.xml
@@ -105,7 +84,6 @@ fabric.properties
 
 # *.iml
 # modules.xml
-# .idea/misc.xml
 # *.ipr
 
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -49,4 +49,4 @@ DEPENDENCIES
   rake
 
 BUNDLED WITH
-   2.1.4
+   2.3.6

--- a/moesif_api.gemspec
+++ b/moesif_api.gemspec
@@ -1,16 +1,16 @@
 Gem::Specification.new do |s|
   s.name = 'moesif_api'
-  s.version = '1.2.13'
+  s.version = '1.2.14'
   s.summary = 'moesif_api'
   s.description = 'Collection/Data Ingestion API'
   s.authors = ['Moesif, Inc', 'Derric Gilling']
   s.email = 'derric@moesif.com'
   s.homepage = 'https://moesif.com'
   s.license = 'Apache-2.0'
-  s.add_dependency('test-unit', '~> 3.1.5')
-  s.add_dependency('moesif_unirest', '~> 1.1.5')
+  s.add_dependency('test-unit', '~> 3.5', '>= 3.5.0')
+  s.add_dependency('moesif_unirest', '~> 1.1.6')
   s.add_dependency('json_mapper', '~> 0.2.1')
-  s.required_ruby_version = '~> 2.0'
+  s.required_ruby_version = '>= 2.0'
   s.files = Dir['{bin,lib,man,test,spec}/**/*', 'README*', 'LICENSE*']
   s.require_paths = ['lib']
 end

--- a/moesif_api.gemspec
+++ b/moesif_api.gemspec
@@ -7,9 +7,9 @@ Gem::Specification.new do |s|
   s.email = 'derric@moesif.com'
   s.homepage = 'https://moesif.com'
   s.license = 'Apache-2.0'
-  s.add_dependency('test-unit', '~> 3.5', '>= 3.5.0')
+  s.add_development_dependency('test-unit', '~> 3.5', '>= 3.5.0')
   s.add_dependency('moesif_unirest', '~> 1.1.6')
-  s.add_dependency('json_mapper', '~> 0.2.1')
+  s.add_dependency('json_mapper', '~> 0.2', '>= 0.2.1')
   s.required_ruby_version = '>= 2.0'
   s.files = Dir['{bin,lib,man,test,spec}/**/*', 'README*', 'LICENSE*']
   s.require_paths = ['lib']


### PR DESCRIPTION
Ticket: https://www.pivotaltracker.com/n/projects/1646401/stories/181066034

Update the Rack SDK to support ruby 3.x
[1/4] https://github.com/Moesif/unirest-ruby/pull/4
[3/4] https://github.com/Moesif/moesif-rack/pull/38
[4/4] https://github.com/Moesif/moesif-rack-example/pull/12